### PR TITLE
move explode outside array_pop, fixes STRICT errors on wp.com scan

### DIFF
--- a/vip-scanner/class-base-scanner.php
+++ b/vip-scanner/class-base-scanner.php
@@ -41,7 +41,10 @@ class BaseScanner {
 	}
 
 	function get_file_type( $filename ) {
-		$file_extension = array_pop( explode( '.', $filename ) );
+		
+		$splosion = explode( '.', $filename );
+
+		$file_extension = array_pop( $splosion );
 
 		foreach( $this->known_extensions as $type => $extensions ) {
 			if( is_array( $extensions ) && in_array( $file_extension, $extensions ) )


### PR DESCRIPTION
Fixes variable passed by reference strict error on wp.com theme scan.
