### PR TITLE
Prevent false positives when using vip_powered_wpcom() for attribution

### DIFF
--- a/vip-scanner-wpcom/checks/VIPWhitelistCheck.php
+++ b/vip-scanner-wpcom/checks/VIPWhitelistCheck.php
@@ -14,7 +14,7 @@ class VIPWhitelistCheck extends BaseCheck
 			//"/<meta\sname=\"generator\"\scontent=\".*WordPress.*\"([^>]+)/msiU" => array( "level" => "Warning", "note" => "Meta tag generator not set or not wordpress.com" ),
 			"/(wp_head)+\s?\(\)/msiU" => array( "level" => "Blocker", "note" => "wp_head() call missing" ),
 			"/(wp_footer)+\s?\(\)/msiU" => array( "level" => "Blocker", "note" => "wp_footer() call missing" ),
-			"/(vip_powered_wpcom)+s?\([^\)]*\)/msiU" => array( "level" => "Warning", "note" => "Attribution link missing or not well formatted" ),
+			"/(vip_powered_wpcom)+s?\([^\)]*\)/msiU" => array( "level" => "Blocker", "note" => "Attribution link missing, please use vip_powered_wpcom()" ),
 		);
 
 		foreach ( $checks as $check => $check_info ) {


### PR DESCRIPTION
This checks if a theme uses vip_powered_wpcom() for outputting the attribution link. It's not fool-proof since the output of that function needs to be echo or printed, but the same can be said of the current check for a link.
