### PR TITLE
Suppress errors for transients that are too big

### DIFF
--- a/vip-scanner.php
+++ b/vip-scanner.php
@@ -133,7 +133,7 @@ class VIP_Scanner_UI {
 
 		$transient_key = 'vip_scanner_' . md5( $theme . $review );
 		if ( $scanner !== get_transient( $transient_key ) )
-			set_transient( $transient_key, $scanner );
+			@set_transient( $transient_key, $scanner );
 
 		if ( $scanner ):
 			$this->display_theme_review_result( $scanner, $theme );
@@ -402,7 +402,7 @@ class VIP_Scanner_UI {
 
 		if ( false === $scanner = get_transient( $transient_key ) ) {
 			$scanner = VIP_Scanner::get_instance()->run_theme_review( $theme, $review );
-			set_transient( $transient_key, $scanner );
+			@set_transient( $transient_key, $scanner );
 		}
 
 		return $scanner;


### PR DESCRIPTION
We're using transients to cache the review results, but if there are too many errors, the transient might be too big to fit into a 1MB cache bucket. It won't get added to the cache, which isn't the end of the world — it will just be slower.

We should still suppress the error telling us that the object is too big for the cache though.
