### PR TITLE
Fixing strict standards error in WP Coding Standards check.

### DIFF
--- a/vip-scanner/checks/WordPressCodingStandardsCheck.php
+++ b/vip-scanner/checks/WordPressCodingStandardsCheck.php
@@ -123,7 +123,8 @@ class WordPressCodingStandardsCheck extends BaseCheck {
 
 				// File header found, set current file
 				$current_file_path = trim( substr( $result, $file_header_pos + strlen( $this->output_parts['file_header'] ) ) );
-				$current_file = end( explode( '/', $current_file_path ) );
+				$exploded_path = explode( '/', $current_file_path );
+				$current_file = end( $exploded_path );
 				$this->increment_check_count();
 				continue;
 			} else if ( is_null( $current_file ) ) {


### PR DESCRIPTION
There is a strict standards issue in the WP Coding Standards check. This fixes it so that no strict standards warnings are shown while executing the check.
