### PR TITLE
Adding filter to skip individual checks during review.

### DIFF
--- a/vip-scanner/class-base-scanner.php
+++ b/vip-scanner/class-base-scanner.php
@@ -137,7 +137,7 @@ class BaseScanner {
 				$check_file = '';
 			}
 
-			if ( apply_filters( "vip-scanner-skip-$check", false ) ) {
+			if ( ! apply_filters( 'vip_scanner_run_check', true, $check ) ) {
 				$this->add_error( 'skipped-check', sprintf( __( 'The "%s" check was skipped.', 'vip-scanner' ), $check ), BaseScanner::LEVEL_WARNING );
 				continue;
 			}


### PR DESCRIPTION
If a "vip-scanner-skip-$check" filter returns true the check will be skipped. Skipping a check generates a warning. `$check` is the name of the check.

Analyzers can also be skipped using this same filter.

Closes: #79
