### PR TITLE
scan_type should be an optional parameter

### DIFF
--- a/vip-scanner/class-wp-cli.php
+++ b/vip-scanner/class-wp-cli.php
@@ -14,7 +14,7 @@ class VIPScanner_Command extends WP_CLI_Command {
 	 * Perform checks on a theme
 	 *
 	 * @subcommand scan-theme
-	 * @synopsis --theme=<theme-name> --scan_type=<scan-type> [--format=<format>] [--summary=<summary>]
+	 * @synopsis --theme=<theme-name> [--scan_type=<scan-type>] [--format=<format>] [--summary=<summary>]
 	 */
 	public function scan_theme( $args, $assoc_args ) {
 		$defaults = array(


### PR DESCRIPTION
In the wp-cli interface, since there’s always a default set for scan-type, it should no longer be a required argument.

Fixes #109
