### PR TITLE
Adding better checker for relative paths in `ThemeScanner`.

### DIFF
--- a/vip-scanner/class-theme-scanner.php
+++ b/vip-scanner/class-theme-scanner.php
@@ -6,10 +6,11 @@ class ThemeScanner extends DirectoryScanner
 		if( ! function_exists( 'get_theme_root' ) )
 			return $this->add_error( 'wp-load', sprintf( '%s requires WordPress to be loaded.', get_class( $this ) ), 'blocker' );
 
- 		//decide whether to interpret theme as a path
-		if ( ( strpos( $theme, '/') !== false ) && !in_array( substr( $theme, 0, 4), array( 'pub/', 'vip/' ) ) ) {
-			$path = $theme;
-		}else{
+ 		// decide whether to interpret theme as a path by checking if the path exists
+		$potential_file_path = realpath( $theme );
+		if ( $potential_file_path ) {
+			$path = $potential_file_path;
+		} else {
 			$path = sprintf( '%s/%s', get_theme_root(), $theme );
 		}
 


### PR DESCRIPTION
Previously the `ThemeScanner` was only checking for the presence of a '/'
in the theme to determine if it was a path or a theme name. This could
fail if the desired theme was within a subfolder of the `themes` folder
other than `vip` or `pub`.

Now, we check and see if the relative path exists and if it does we assume
the user supplied a path rather than a theme name. This will also allow
specifying relative paths such as `.` or `../../`.

See bd523ad7621046a4ad6ae8cb58e9535e96f71536
