### PR TITLE
Remove WordPressCodingStandardsCheck from wp.com review

### DIFF
--- a/vip-scanner/config-vip-scanner.php
+++ b/vip-scanner/config-vip-scanner.php
@@ -28,7 +28,6 @@ VIP_Scanner::get_instance()->register_review( 'WP.com Theme Review', array(
 	'ThemecolorsCheck',
 	'VCMergeConflictCheck',
 	'PHPClosingTagsCheck',
-	'WordPressCodingStandardsCheck',
 ), array(
 	'PHPAnalyzer',
 	'CustomResourceAnalyzer',


### PR DESCRIPTION
We don't need this for the moment, and it also removes the dependency on
phpcs and the WPCS rules.
