### PR TITLE
Remove trailing slash from the theme Domain Path header check.

### DIFF
--- a/vip-scanner/checks/LanguagePacksCheck.php
+++ b/vip-scanner/checks/LanguagePacksCheck.php
@@ -46,7 +46,7 @@ class LanguagePacksCheck extends BaseCheck {
 		$domain_path = array();
 		preg_match( '/Domain Path:(.*)$/mi', $css_code, $domain_path );
 
-		if ( '/languages/' != trim( $domain_path[1] ) ) {
+		if ( '/languages' != trim( $domain_path[1] ) ) {
 			$this->add_error(
 				'language-packs',
 				'You need to indicate a domain path in your <code>style.css</code> file header: <code>Domain Path: /languages/</code>.',


### PR DESCRIPTION
The Domain Path header tag shouldn't have a trailing slash, otherwise core will double up the slash when concatenating the path with the POT file.

[Here's where the Domain Path](https://github.com/WordPress/WordPress/blob/4bff4ff2d6623e500785b70f48f241e6969f072b/wp-includes/class-wp-theme.php#L1057) is accounted for (you can see the default below, which doesn't have the trailing slash).

And here's where that path is [prepended to the POT file name](https://github.com/WordPress/WordPress/blob/4bff4ff2d6623e500785b70f48f241e6969f072b/wp-includes/l10n.php#L647).
