### PR TITLE
'get_children()' flagged as a blocker

### DIFF
--- a/vip-scanner/checks/ForbiddenFunctionsCheck.php
+++ b/vip-scanner/checks/ForbiddenFunctionsCheck.php
@@ -22,6 +22,7 @@ class ForbiddenFunctionsCheck extends BaseCheck {
 			'add_meta_box',
 			'add_help_tab',
 			'query_posts',
+			'get_children',
 		);
 
 		$php = $this->merge_files( $files, 'php' );


### PR DESCRIPTION
This WordPress function can be pretty dangerous. Check the issue https://github.com/Automattic/vip-scanner/issues/123
