### PR TITLE
Apply a filter to the WP.com checks config

### DIFF
--- a/vip-scanner/config-vip-scanner.php
+++ b/vip-scanner/config-vip-scanner.php
@@ -9,7 +9,7 @@ VIP_Scanner::get_instance()->register_review( 'Undefined Function Check', array(
 	'UndefinedFunctionCheck',
 ) );
 
-VIP_Scanner::get_instance()->register_review( 'WP.com Theme Review', array(
+VIP_Scanner::get_instance()->register_review( 'WP.com Theme Review', apply_filters( 'vip_scanner_include_checks', array(
 	'AtPackageCheck',
 	'BodyClassCheck',
 	'CDNCheck',
@@ -41,7 +41,7 @@ VIP_Scanner::get_instance()->register_review( 'WP.com Theme Review', array(
 	// 'WhitespaceCheck',
 	'WidgetsCheck',
 	'JavaScriptLintCheck',
-), array(
+) ), array(
 	'PHPAnalyzer',
 	'CustomResourceAnalyzer',
 	'ThemeAnalyzer',


### PR DESCRIPTION
This is so we can filter out checks that won't work with the .zip scanner on
WP.com yet, whilst keeping one .com config, so we're not maintaining two lists.
