### PR TITLE
Adds a check for VIP restricted command "switch_theme"

### DIFF
--- a/tests/checks/test-VIPRestrictedCommandsCheck.php
+++ b/tests/checks/test-VIPRestrictedCommandsCheck.php
@@ -476,5 +476,13 @@ class VIPRestrictedCommandsCheckTest extends WP_UnitTestCase {
 
 		$this->checkCommands( $restricted_commands );
 	}
+
+	public function testSwitchTheme() {
+		$restricted_commands = array(
+			'switch_theme'
+		);
+
+		$this->checkCommands( $restricted_commands );
+	}
 }
 

--- a/vip-scanner/checks/VIPRestrictedCommandsCheck.php
+++ b/vip-scanner/checks/VIPRestrictedCommandsCheck.php
@@ -87,6 +87,7 @@ class VIPRestrictedCommandsCheck extends BaseCheck
 			'create_function' 			=> array( 'level' => 'Blocker', "note" => "Using create_function, consider annonymous functions" ),
 			'extract' 					=> array( 'level' => 'Blocker', "note" => "Explicitly define variables rather than using extract()" ),
 			"ini_set" 					=> array( "level" => "Blocker", "note" => "Settings alteration" ),
+			"switch_theme" 				=> array( "level" => "Blocker", "note" => "Switching theme programmatically is not allowed. Please make the update by hand after a deploy of your code" ),
 			"wp_is_mobile" 				=> array( "level" => "Warning", "note" => "wp_is_mobile() is not batcache-friendly, please use <a href=\"http://vip.wordpress.com/documentation/mobile-theme/#targeting-mobile-visitors\">jetpack_is_mobile()</a>" ),
 
 			// Restricted widgets


### PR DESCRIPTION
switch_theme is not an allowed command and when it's needed, the switch should be done by hand. It's a blocker and is being flagged in that way.

The PR also add a test for this use case.

work toward: https://github.com/Automattic/vip-scanner/issues/170
