### PR TITLE
Add a warning for possible direct access to $wp_query->query_vars

### DIFF
--- a/tests/checks/test-VIPRestrictedPatternsCheck.php
+++ b/tests/checks/test-VIPRestrictedPatternsCheck.php
@@ -65,4 +65,33 @@ EOT;
 		$this->assertNotContains( '/(\$_REQUEST)+/msiU', $error_slugs );
 	}
 
+	public function testQueryVarsDirectAccessGet() {
+		$file_contents = <<<'EOT'
+			<?php
+
+			add_action( "init", function(){
+				global $wp_query;
+				$paged = $wp_query->query_vars["paged"];
+			} );
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+
+		$this->assertContains( '/\$wp_query->query_vars\[.*?\][^=]*?\;/msi', $error_slugs );
+	}
+
+	public function testQueryVarsDirectAccessSet() {
+		$file_contents = <<<'EOT'
+			<?php
+
+			add_action( "init", function(){
+				global $wp_query;
+				$wp_query->query_vars["paged"] = 3;
+			} );
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+
+		$this->assertContains( '/\$wp_query->query_vars\[.*?\]\s*?\=.*?\;/msi', $error_slugs );
+	}
 }

--- a/vip-scanner/checks/VIPRestrictedPatternsCheck.php
+++ b/vip-scanner/checks/VIPRestrictedPatternsCheck.php
@@ -19,6 +19,8 @@ class VIPRestrictedPatternsCheck extends BaseCheck
 			"/(\\\$GLOBALS|\\\$_SERVER|\\\$_GET|\\\$_POST|\\\$_REQUEST)+/msiU" => array( "level" => "Note", "note" => "Working with superglobals" ),
 			"/(\\\$_SERVER\[(?!('|\"REQUEST_URI|SCRIPT_FILENAME|HTTP_HOST'|\"))([^]]+|)\])+/msiU" => array( "level" => "Blocker", "note" => 'Non whitelisted $_SERVER superglobals found in this file' ),
 			"/(pre_)?option_(blogname|siteurl|post_count)/msiU" => array( "level" => "Blocker", "note" => "possible unsafe use of pre_option_* hook"),
+			"/\\\$wp_query->query_vars\[.*?\][^=]*?\;/msi" => array( "level" => "Warning", "note" => "Possible direct query_vars access, should use get_query_var() function" ),
+			"/\\\$wp_query->query_vars\[.*?\]\s*?\=.*?\;/msi" => array( "level" => "Warning", "note" => "Possible direct query_vars modification, should use set_query_var() function" )
 		);
 
 		foreach ( $this->filter_files( $files, 'php' ) as $file_path => $file_content ) {


### PR DESCRIPTION
This is a cleaned up version of @david-binda's #165, with commits squashed.
