### PR TITLE
Add usage instructions to readme.md and readme.txt

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Requires WordPress version 3.4 or greater.
 About
 -----
 
-The plugin itself is simply a UI for the VIP Scanner library, which does all the heavy lifting. The library allows you to create arbitrary "Checks" (e.g. UndefinedFunctionCheck), group them together as Reviews (WordPress.org Theme Review), and run them against themes, plugins, directories, single files, and even diffs.
+The plugin itself is simply a UI for the VIP Scanner library, which does all the heavy lifting. The library allows you to create arbitrary "Checks" (e.g. UndefinedFunctionCheck), group them together as Reviews (e.g. WP.com Theme Review), and run them against themes, plugins, directories, single files, and even diffs.
 
 This plugin is based on code from the [Theme Check](http://wordpress.org/extend/plugins/theme-check/) (written by [Pross](http://profiles.wordpress.org/pross/) and [Otto42](http://profiles.wordpress.org/otto42/)) and [Exploit Scanner](http://wordpress.org/extend/plugins/exploit-scanner/)  (written by [donncha](http://profiles.wordpress.org/donncha/)) plugins.
 

--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ Scan all sorts of themes and files and things.
 
 Scan all sorts of themes and files and things.
 
-The plugin itself is simple a UI for the VIP Scanner library, which does all the heavy lifting. The library allows you to create arbitrary "Checks" (e.g. UndefinedFunctionCheck), group them together as Reviews (WordPress.org Theme Review), and run them against themes, plugins, directories, single files, and even diffs.
+The plugin itself is simple a UI for the VIP Scanner library, which does all the heavy lifting. The library allows you to create arbitrary "Checks" (e.g. UndefinedFunctionCheck), group them together as Reviews (e.g. WP.com Theme Review), and run them against themes, plugins, directories, single files, and even diffs.
 
 This plugin is based on code from the <a href="http://wordpress.org/extend/plugins/theme-check/">Theme Check</a> (written by Pross and Otto42) and <a href="http://wordpress.org/extend/plugins/exploit-scanner/">Exploit Scanner</a> (written by donncha) plugins.
 


### PR DESCRIPTION
Based on @david-binda's work, updated to reflect current WP CLI invocation, plus some line breaks and style fixes. Also, readme.md was missing the 0.8 Changelog entry; and I replaced a 'WordPress.org Theme Review' string with 'WP.com Theme Review'.
