### PR TITLE
Replace list of require_once statements by an autoloader

### DIFF
--- a/tests/checks/test-BaseScanner.php
+++ b/tests/checks/test-BaseScanner.php
@@ -5,7 +5,6 @@ class BaseScannerTest extends WP_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();
-		require_once VIP_SCANNER_SCANNERS_DIR . '/class-base-scanner.php';
 
 		$this->resetBaseScanner();
 	}


### PR DESCRIPTION
Loading all classes at once on startup would fatal if there
were missing dependencies in one of those files. Loading
files dynamically when the classes they contain are needed
allows for displaying error messages if a dependency can not
be found.