### PR TITLE
Display errors also when invoking VIP-scanner's CLI with the analyze-theme subcommand

### DIFF
--- a/vip-scanner/class-wp-cli.php
+++ b/vip-scanner/class-wp-cli.php
@@ -79,6 +79,10 @@ class VIPScanner_Command extends WP_CLI_Command {
 			WP_CLI::error( sprintf( 'Scanning of %s failed', $args['theme'] ) );
 		}
 
+		if ( ! empty( $scanner->get_errors() ) ) {
+			$this->display_errors( $scanner, 'table' );
+		}
+
 		$empty = array();
 		$display_args = array(
 			'bare'  => true,

--- a/vip-scanner/class-wp-cli.php
+++ b/vip-scanner/class-wp-cli.php
@@ -138,9 +138,15 @@ class VIPScanner_Command extends WP_CLI_Command {
 				'value' => count( $results['errors'] )
 		);
 
+		$plurals = array(
+			BaseScanner::LEVEL_BLOCKER => __( 'Blockers' ),
+			BaseScanner::LEVEL_WARNING => __( 'Warnings' ),
+			BaseScanner::LEVEL_NOTE    => __( 'Notes' ),
+		);
+
 		foreach ( $scanner->get_error_levels() as $level ) {
-			$label 			= __( ucfirst( $level ) . 's' );
-			$error_count 	= count( $scanner->get_errors( array( $level ) ) );
+			$label       = $plurals[ $level ];
+			$error_count = count( $scanner->get_errors( array( $level ) ) );
 
 			$data[] = array(
 					'key' 	=> $label,


### PR DESCRIPTION
Some errors don't need any check to be run, they are diagnosed by the scanner itself
(like an empty theme directory). As these errors can cause the analyze-theme subcommand
to fail, they should be displayed.