### PR TITLE
Prevent false positives with the Restricted Patterns check

### DIFF
--- a/tests/checks/test-VIPRestrictedPatternsCheck.php
+++ b/tests/checks/test-VIPRestrictedPatternsCheck.php
@@ -76,8 +76,6 @@ EOT;
 			'echo $GLOBALS;',
 			'echo $_SERVER;',
 			'echo $_REQUEST;',
-			'print_r( $_SERVER );',
-			'var_dump( $_POST );',
 			'echo "Hello, " . $_GET["name"]',
 			'sprintf( "Hello, %s", $_GET["name"] );'
 		);
@@ -92,7 +90,7 @@ EOT;
 EOT;
 
 			$this->assertContains(
-				'/(echo|print|var_dump|\<\?\=)+(?!\s+\(?\s*(?:isset|typeof)\(\s*)[^;]+(\$GLOBALS|\$_SERVER|\$_GET|\$_POST|\$_REQUEST)+/msiU',
+				'/(echo|\<\?\=)+(?!\s+\(?\s*(?:isset|typeof)\(\s*)[^;]+(\$GLOBALS|\$_SERVER|\$_GET|\$_POST|\$_REQUEST)+/msiU',
 				$this->runCheck( $file_contents )
 			);
 		}
@@ -117,7 +115,7 @@ EOT;
 EOT;
 
 			$this->assertNotContains(
-				'/(echo|print|var_dump|\<\?\=)+(?!\s+\(?\s*(?:isset|typeof)\(\s*)[^;]+(\$GLOBALS|\$_SERVER|\$_GET|\$_POST|\$_REQUEST)+/msiU',
+				'/(echo|\<\?\=)+(?!\s+\(?\s*(?:isset|typeof)\(\s*)[^;]+(\$GLOBALS|\$_SERVER|\$_GET|\$_POST|\$_REQUEST)+/msiU',
 				$this->runCheck( $file_contents )
 			);
 		}

--- a/tests/checks/test-VIPRestrictedPatternsCheck.php
+++ b/tests/checks/test-VIPRestrictedPatternsCheck.php
@@ -32,7 +32,7 @@ EOT;
 		$error_slugs = $this->runCheck( $file_contents );
 
 		$this->assertNotContains( '/(\$_REQUEST)+/msiU', $error_slugs );
-	} 
+	}
 
 	public function testReadingREQUESTVariables() {
 		$file_contents = <<<'EOT'
@@ -63,6 +63,64 @@ EOT;
 		$error_slugs = $this->runCheck( $file_contents );
 
 		$this->assertNotContains( '/(\$_REQUEST)+/msiU', $error_slugs );
+	}
+
+	public function testOutputRestrictedVariables() {
+		$patterns = array(
+			'echo $_GET["foo"];',
+			'echo $_GET["var"];',
+			'echo( $_GET["foo"] );',
+			'echo $_GET;',
+			'print $_GET;',
+			'echo $_POST;',
+			'echo $GLOBALS;',
+			'echo $_SERVER;',
+			'echo $_REQUEST;',
+			'print_r( $_SERVER );',
+			'var_dump( $_POST );',
+			'echo "Hello, " . $_GET["name"]',
+			'sprintf( "Hello, %s", $_GET["name"] );'
+		);
+
+		foreach ( $patterns as $pattern ) {
+			$file_contents = <<<EOT
+			<?php
+
+			{$pattern}
+
+			?>
+EOT;
+
+			$this->assertContains(
+				'/(echo|print|var_dump|\<\?\=)+(?!\s+\(?\s*(?:isset|typeof)\(\s*)[^;]+(\$GLOBALS|\$_SERVER|\$_GET|\$_POST|\$_REQUEST)+/msiU',
+				$this->runCheck( $file_contents )
+			);
+		}
+	}
+
+	// Patterns that shouldn't set off red flags
+	public function testOutputRestrictedVariablesFalsePositives() {
+		$patterns = array(
+			'echo $foo; isset( $_GET["bar"] );',
+			'echo isset( $_GET ) ? "foo" : "bar";',
+			'echo typeof( $_GET ) == "array" ? "yes" : "no";',
+			'echo ( isset( $_GET["checked"] ) ? "is" : "not";'
+		);
+
+		foreach ( $patterns as $pattern ) {
+			$file_contents = <<<EOT
+			<?php
+
+			{$pattern}
+
+			?>
+EOT;
+
+			$this->assertNotContains(
+				'/(echo|print|var_dump|\<\?\=)+(?!\s+\(?\s*(?:isset|typeof)\(\s*)[^;]+(\$GLOBALS|\$_SERVER|\$_GET|\$_POST|\$_REQUEST)+/msiU',
+				$this->runCheck( $file_contents )
+			);
+		}
 	}
 
 	public function testQueryVarsDirectAccessGet() {

--- a/vip-scanner/checks/VIPRestrictedPatternsCheck.php
+++ b/vip-scanner/checks/VIPRestrictedPatternsCheck.php
@@ -15,7 +15,7 @@ class VIPRestrictedPatternsCheck extends BaseCheck
 			"/(\\\$wpdb->|mysql_)+.+(DELETE)+\s+(FROM)+\s+/msiU" => array( "level" => "Warning", "note" => "Direct database delete query" ),
 			"/(\\\$wpdb->|mysql_)+.+(SELECT)+\s.+/msiU" => array( "level" => "Note", "note" => "Direct Database select query" ),
 			"/(^GLOBAL)(\\\$wpdb->|mysql_)+/msiU" => array( "level" => "Warning", "note" => "Possible direct database query" ),
-			'/(echo|print|var_dump|\<\?\=)+(?!\s+\(?\s*(?:isset|typeof)\(\s*)[^;]+(\$GLOBALS|\$_SERVER|\$_GET|\$_POST|\$_REQUEST)+/msiU' => array( "level" => "Warning", "note" => "Possible output of restricted variables" ),
+			'/(echo|\<\?\=)+(?!\s+\(?\s*(?:isset|typeof)\(\s*)[^;]+(\$GLOBALS|\$_SERVER|\$_GET|\$_POST|\$_REQUEST)+/msiU' => array( "level" => "Warning", "note" => "Possible output of restricted variables" ),
 			"/(\\\$GLOBALS|\\\$_SERVER|\\\$_GET|\\\$_POST|\\\$_REQUEST)+/msiU" => array( "level" => "Note", "note" => "Working with superglobals" ),
 			"/(\\\$_SERVER\[(?!('|\"REQUEST_URI|SCRIPT_FILENAME|HTTP_HOST'|\"))([^]]+|)\])+/msiU" => array( "level" => "Blocker", "note" => 'Non whitelisted $_SERVER superglobals found in this file' ),
 			"/(pre_)?option_(blogname|siteurl|post_count)/msiU" => array( "level" => "Blocker", "note" => "possible unsafe use of pre_option_* hook"),

--- a/vip-scanner/checks/VIPRestrictedPatternsCheck.php
+++ b/vip-scanner/checks/VIPRestrictedPatternsCheck.php
@@ -15,7 +15,7 @@ class VIPRestrictedPatternsCheck extends BaseCheck
 			"/(\\\$wpdb->|mysql_)+.+(DELETE)+\s+(FROM)+\s+/msiU" => array( "level" => "Warning", "note" => "Direct database delete query" ),
 			"/(\\\$wpdb->|mysql_)+.+(SELECT)+\s.+/msiU" => array( "level" => "Note", "note" => "Direct Database select query" ),
 			"/(^GLOBAL)(\\\$wpdb->|mysql_)+/msiU" => array( "level" => "Warning", "note" => "Possible direct database query" ),
-			"/(echo|print|\<\?\=)+.+(\\\$GLOBALS|\\\$_SERVER|\\\$_GET|\\\$_POST|\\\$_REQUEST)+/msiU" => array( "level" => "Warning", "note" => "Possible output of restricted variables" ),
+			'/(echo|print|var_dump|\<\?\=)+(?!\s+\(?\s*(?:isset|typeof)\(\s*)[^;]+(\$GLOBALS|\$_SERVER|\$_GET|\$_POST|\$_REQUEST)+/msiU' => array( "level" => "Warning", "note" => "Possible output of restricted variables" ),
 			"/(\\\$GLOBALS|\\\$_SERVER|\\\$_GET|\\\$_POST|\\\$_REQUEST)+/msiU" => array( "level" => "Note", "note" => "Working with superglobals" ),
 			"/(\\\$_SERVER\[(?!('|\"REQUEST_URI|SCRIPT_FILENAME|HTTP_HOST'|\"))([^]]+|)\])+/msiU" => array( "level" => "Blocker", "note" => 'Non whitelisted $_SERVER superglobals found in this file' ),
 			"/(pre_)?option_(blogname|siteurl|post_count)/msiU" => array( "level" => "Blocker", "note" => "possible unsafe use of pre_option_* hook"),


### PR DESCRIPTION
Under certain circumstances the check for restricted patterns is too lose, causing "Possible output of restricted variables" warnings to be thrown for innocent lines like `echo $foo; $has_bar = isset( $_GET['bar'] );`.

This pull request adds tests around the intended matches for the original regex pattern, then tweaks the pattern so it won't cross boundaries of semi-colons or functions like `isset()`. It also adds a check for `var_dump()`'ing a super global.