### PR TITLE
Allow using require_once as statement without parenthesis

### DIFF
--- a/tests/checks/test-VIPInitCheck.php
+++ b/tests/checks/test-VIPInitCheck.php
@@ -16,6 +16,10 @@ class VIPInitCheckTest extends WP_UnitTestCase {
 		$this->assertTrue( $this->_VIPInitCheckTest->vip_init_is_included( $this->_functions_file ) );
 	}
 
+	public function testStatementRequire() {
+		$this->assertTrue( $this->_VIPInitCheckTest->vip_init_is_included( dirname(__FILE__) . '/../data/test-theme2/functions.php' ) );
+	}
+
 	public function testScanner() {
 		$vipsccanner = VIP_Scanner::get_instance();
 		$vipsccanner->register_review( 'VIPInitCheck', array(

--- a/tests/data/test-theme2/functions.php
+++ b/tests/data/test-theme2/functions.php
@@ -1,0 +1,4 @@
+<?php
+
+// Init WP.com VIP environment
+require_once WP_CONTENT_DIR . '/themes/vip/plugins/vip-init.php';

--- a/vip-scanner/checks/VIPInitCheck.php
+++ b/vip-scanner/checks/VIPInitCheck.php
@@ -48,7 +48,7 @@ class VIPInitCheck extends BaseCheck {
 	}
 
 	public function vip_init_is_included( $file ) {
-		$matches = $this->preg_file( '/\brequire_once?\s*?\(\s*?WP_CONTENT_DIR\s*?\.\s*?(\'|\")\/themes\/vip\/plugins\/vip-init\.php\1/', $file );
+		$matches = $this->preg_file( '/\brequire_once?\s*?\(?\s*?WP_CONTENT_DIR\s*?\.\s*?(\'|\")\/themes\/vip\/plugins\/vip-init\.php\1/', $file );
 
 		return ( count( $matches ) ) ? true : false;
 	}


### PR DESCRIPTION
Modifying the vip-init.php presence check the way it takes into consider using ``require_once`` as statement without parenthesis as it was brought to attention in https://github.com/Automattic/vip-scanner/issues/49

Looks like I misunderstood the [conversation about allowing path taken directly from our documentation](https://github.com/Automattic/vip-scanner/pull/169#discussion-diff-18991947) and was stricter that it is necessary.

This PR makes the parenthesis in ``require_once`` optional and adds unit tests for this situation.