### PR TITLE
Jetpack Responsive Videos: Set priority from Warning to Blocker.

### DIFF
--- a/vip-scanner/checks/JetpackCheck.php
+++ b/vip-scanner/checks/JetpackCheck.php
@@ -31,7 +31,7 @@ class JetpackCheck extends BaseCheck {
 				$this->add_error(
 					'jetpack',
 					"The theme has not declared support for Jetpack Responsive Videos. Use <code>add_theme_support( 'jetpack-responsive-videos' );</code> in your <code>inc/jetpack.php</code> file",
-					Basescanner::LEVEL_WARNING
+					Basescanner::LEVEL_BLOCKER
 				);
 				$result = false;
 			}


### PR DESCRIPTION
Updated JetpackCheck.php to set Jetpack Responsive Videos as a requirement/blocker. This was done to reflect a recent update in the [documentation](https://developer.wordpress.com/themes/).

See conversation [here](https://github.com/Automattic/vip-scanner/issues/235#issuecomment-72877665).