### PR TITLE
VIP Scanner: Added check for PHP variable variables.

### DIFF
--- a/vip-scanner/checks/VIPRestrictedVariablesCheck.php
+++ b/vip-scanner/checks/VIPRestrictedVariablesCheck.php
@@ -1,0 +1,36 @@
+<?php
+
+class VIPRestrictedVariablesCheck extends BaseCheck
+{
+	function check( $files ) {
+		$result = true;
+
+		$checks = array(
+			'((?<![\\\'\"])\$\$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*?(?![\\\'\"])|(?<![\\\'\"])\$\{(?:.*)[\}](?![\\\'\"]))' => array( "level" => "Warning", "note" => "Possible variable variables" ),
+		);
+
+		foreach ( $this->filter_files( $files, 'php' ) as $file_path => $file_content ) {
+			foreach ( $checks as $check => $check_info ) {
+				$this->increment_check_count();
+
+				if ( preg_match_all( $check, $file_content, $matches ) ) {
+					$filename = $this->get_filename( $file_path );
+					$lines = array();
+					foreach ( $matches[0] as $match ) {
+						$lines = array_merge( $this->grep_content( $match, $file_content ), $lines );
+					}
+					$this->add_error(
+						$check,
+						$check_info['note'],
+						$check_info['level'],
+						$filename,
+						$lines
+					);
+					$result = false;
+				}
+			}
+		}
+
+		return $result;
+	}
+}

--- a/vip-scanner/config-vip-scanner.php
+++ b/vip-scanner/config-vip-scanner.php
@@ -61,6 +61,7 @@ VIP_Scanner::get_instance()->register_review( 'VIP Theme Review', array(
 	'jQueryCheck',
 	'VIPWhitelistCheck',
 	'VIPRestrictedClassesCheck',
+	'VIPRestrictedVariablesCheck',
 	'VIPRestrictedPatternsCheck',
 	'VIPRestrictedCommandsCheck',
 	'VIPInitCheck',


### PR DESCRIPTION
VIPRestrictedPatternsCheck.php was using preg_match() and would not show a complete list of found results, so I created a new Check that uses preg_match_all() to list all of the results.

Uses the following regex: `((?<![\'\"])\$\$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*?(?![\'\"])|(?<![\'\"])\$\{(?:.*)[\}](?![\'\"]))`

>If not preceeded by either " or ', search for "$$" and a valid PHP variable name, as long as it is not followed by either " or '
>*OR*
>If not preceeded by either " or ', search for "${" and end the search with "}", as long as it is not followed by either " or '

Try as I might, I was unable to find a solution to some false positives using regex.

If a file has embedded content outside of PHP tags, the content may still be caught by the regex.  Example:

```php
<?php get_header(); ?>
<h1>Government wasted $$$$millions; What next?</h1>
<?php ...
```

We cannot make another check to verify that the regex IS inside proper PHP tags because there may not be a closing tag on the file.
This approach could cause the regex to fail to find actual potential variable variables.