### PR TITLE
VIP Scanner: Added html escaping to scan descriptions in scan results.

### DIFF
--- a/vip-scanner.php
+++ b/vip-scanner.php
@@ -313,7 +313,7 @@ class VIP_Scanner_UI {
 
 		?>
 		<li class="scan-result-<?php echo strtolower( $level ); ?>">
-			<span class="scan-description"><?php echo $description; ?></span>
+			<span class="scan-description"><?php echo esc_html( $description ); ?></span>
 
 			<?php if( ! empty( $file ) ) : ?>
 				<span class="scan-file">


### PR DESCRIPTION
Per GitHub Issue #263, `display_theme_review_result_row()` was not escaping html when it output `$description`.