### PR TITLE
VIP Scanner: filter_files() now accepts arrays of file types.

### DIFF
--- a/vip-scanner/class-base-check.php
+++ b/vip-scanner/class-base-check.php
@@ -57,13 +57,13 @@ abstract class BaseCheck
 		$files = (array) $files;
 		if ( $type ) {
 			if ( is_array( $type ) ) {
-				$file_types = array();
+				$files_of_multiple_types = array();
 				foreach ( $type as $single_type ) {
 					if ( isset( $files[ $single_type ] ) ) {
-						$file_types = array_merge( $file_types, $files[ $single_type ] );
+						$files_of_multiple_types = array_merge( $files_of_multiple_types, $files[ $single_type ] );
 					}
 				}
-				return $file_types;
+				return $files_of_multiple_types;
 			} else {
 				if ( isset( $files[ $type ] ) ) {
 					return $files[ $type ];

--- a/vip-scanner/class-base-check.php
+++ b/vip-scanner/class-base-check.php
@@ -55,11 +55,23 @@ abstract class BaseCheck
 
 	protected function filter_files( $files, $type = '' ) {
 		$files = (array) $files;
-		if( $type ) {
-			if( isset( $files[$type] ) )
-				return $files[$type];
-			else
-				return array();
+		if ( $type ) {
+			if ( is_array( $type ) ) {
+				$file_types = array();
+				foreach ( $type as $single_type ) {
+					if ( isset( $files[ $single_type ] ) ) {
+						$file_types = array_merge( $file_types, $files[ $single_type ] );
+					}
+				}
+				return $file_types;
+			} else {
+				if ( isset( $files[ $type ] ) ) {
+					return $files[ $type ];
+				}
+				else {
+					return array();
+				}
+			}
 		}
 		return $files;
 	}


### PR DESCRIPTION
This should be a solution to GitHub issue #265.

I made this change so that when searching for XSS vulnerabilities, I wouldn't have to run through two `foreach ( $this->filter_files() )` blocks--one for PHP and one for HTML.

It should make scanning multiple types at once much easier.
