### PR TITLE
Basic flagging of HTTP protocol-specific URLs.

### DIFF
--- a/tests/checks/CheckTestBase.php
+++ b/tests/checks/CheckTestBase.php
@@ -13,7 +13,11 @@ abstract class CheckTestBase extends WP_UnitTestCase {
 	}
 
 	public function runCheck( $file_contents ) {
-		$input = array( 'php' => array( 'test.php' => $file_contents ) );
+		$input = array(
+			'php' => array('test.php' => $file_contents ),
+			'css' => array('test.css' => $file_contents ),
+			'js' => array('test.js' => $file_contents ),
+		);
 
 		$result = $this->check->check( $input );
 		$errors = $this->check->get_errors();

--- a/tests/checks/test-URISchemeCheck.php
+++ b/tests/checks/test-URISchemeCheck.php
@@ -1,0 +1,179 @@
+<?php
+
+require_once( 'CheckTestBase.php' );
+
+class URISchemeTest extends CheckTestBase {
+
+	public function test_in_css() {
+		$file_contents = <<<'EOT'
+			body {
+				background-image: url(http://www.example.com/bg.jpg);
+			}
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+		$this->assertContains( 'hardcoded-http-scheme', $error_slugs );
+	}
+
+	public function test_not_in_css() {
+		$file_contents = <<<'EOT'
+			body {
+				background-color: #FFFFFF;
+			}
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+		$this->assertNotContains( 'hardcoded-http-scheme', $error_slugs );
+	}
+
+	public function test_in_js() {
+		$file_contents = <<<'EOT'
+			var ajax_url = 'http://www.example.com/test.json';
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+		$this->assertContains( 'hardcoded-http-scheme', $error_slugs );
+	}
+
+	public function test_not_in_js() {
+		$file_contents = <<<'EOT'
+			var ajax_url = '//www.example.com/test.json';
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+		$this->assertNotContains( 'hardcoded-http-scheme', $error_slugs );
+	}
+
+	public function test_in_php_wp_enqueue() {
+		$file_contents = <<<'EOT'
+		<?php
+			wp_enqueue_script( 'script-name', 'http://www.example.com/test.js', array(), '1.0.0', true );
+		?>
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+		$this->assertContains( 'script-and-style-link-hardcoded-http-scheme', $error_slugs );
+	}
+
+	public function test_not_in_php_wp_enqueue() {
+		$file_contents = <<<'EOT'
+		<?php
+			wp_enqueue_script( 'script-name', get_template_directory_uri() . '/js/example.js', array(), '1.0.0', true );
+		?>
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+		$this->assertNotContains( 'script-and-style-link-hardcoded-http-scheme', $error_slugs );
+	}
+
+	public function test_in_html_object_tag() {
+		$file_contents = <<<'EOT'
+			<object width="400" height="400" data="http://www.example.com/test.swf"></object>
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+		$this->assertContains( 'html-object-tag-data-attribute-hardcoded-http-scheme', $error_slugs );
+	}
+
+	public function test_not_in_html_object_tag() {
+		$file_contents = <<<'EOT'
+			<object width="400" height="400" data="//www.example.com/test.swf"></object>
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+		$this->assertNotContains( 'html-object-tag-data-attribute-hardcoded-http-scheme', $error_slugs );
+	}
+
+	public function test_in_html_menuitem_tag() {
+		$file_contents = <<<'EOT'
+<menu type="context" id="mymenu">
+	<menuitem label="Refresh" onclick="window.location.reload();" icon="http://www.example.com/example.png"></menuitem>
+</menu>
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+		$this->assertContains( 'html-menuitem-tag-icon-attribute-hardcoded-http-scheme', $error_slugs );
+	}
+
+	public function test_not_in_html_menuitem_tag() {
+		$file_contents = <<<'EOT'
+<menu type="context" id="mymenu">
+	<menuitem label="Refresh" onclick="window.location.reload();" icon="//www.example.com/example.png"></menuitem>
+</menu>
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+		$this->assertNotContains( 'html-menuitem-tag-icon-attribute-hardcoded-http-scheme', $error_slugs );
+	}
+
+	public function test_in_html_tag() {
+		$file_contents = <<<'EOT'
+<html manifest="http://example.com/app1/manifest">
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+		$this->assertContains( 'html-html-tag-manifest-attribute-hardcoded-http-scheme', $error_slugs );
+	}
+
+	public function test_not_in_html_tag() {
+		$file_contents = <<<'EOT'
+<html manifest="//example.com/app1/manifest">
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+		$this->assertNotContains( 'html-html-tag-manifest-attribute-hardcoded-http-scheme', $error_slugs );
+	}
+
+	public function test_in_html_video_tag() {
+		$file_contents = <<<'EOT'
+<video width="320" height="240" controls poster="http://www.example.com/movie.jpg">
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+		$this->assertContains( 'html-video-tag-poster-attribute-hardcoded-http-scheme', $error_slugs );
+	}
+
+	public function test_not_in_html_video_tag() {
+		$file_contents = <<<'EOT'
+<video width="320" height="240" controls poster="//www.example.com/movie.jpg">
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+		$this->assertNotContains( 'html-video-tag-poster-attribute-hardcoded-http-scheme', $error_slugs );
+	}
+
+	public function test_in_html_tag_src_attribute() {
+		$file_contents = <<<'EOT'
+<audio src="http://www.example.com/audio.mp3">
+<embed src="http://www.example.com/movie.swf">
+<iframe src="http://www.example.com/page.html">
+<img src="http://www.example.com/image.jpg">
+<input src="http://www.example.com/image.jpg">
+<script src="http://www.example.com/script.js">
+<source src="http://www.example.com/movie.mp4">
+<track src="http://www.example.com/subtitles.vtt">
+<video src="http://www.example.com/movie.mp4">
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+		$this->assertContains( 'html-tag-src-attribute-hardcoded-http-scheme', $error_slugs );
+	}
+
+	public function test_not_in_html_tag_src_attribute() {
+		$file_contents = <<<'EOT'
+<audio src="//www.example.com/audio.mp3">
+<embed src="//www.example.com/movie.swf">
+<iframe src="//www.example.com/page.html">
+<img src="//www.example.com/image.jpg">
+<input src="//www.example.com/image.jpg">
+<script src="//www.example.com/script.js">
+<source src="//www.example.com/movie.mp4">
+<track src="//www.example.com/subtitles.vtt">
+<video src="//www.example.com/movie.mp4">
+EOT;
+
+		$error_slugs = $this->runCheck( $file_contents );
+		$this->assertNotContains( 'html-tag-src-attribute-hardcoded-http-scheme', $error_slugs );
+	}
+
+}

--- a/vip-scanner/checks/URISchemeCheck.php
+++ b/vip-scanner/checks/URISchemeCheck.php
@@ -147,22 +147,25 @@ class URISchemeCheck extends BaseCheck
 		foreach ( $this->filter_files( $files, array( 'php', 'html' ) ) as $file_path => $file_content ) {
 			foreach ( $checks as $check => $check_info ) {
 				$this->increment_check_count();
+				$lines = array();
 				if ( preg_match_all( $check_info['expression'], $file_content, $matches ) ) {
-					$lines = array();
 					foreach ( $matches['MATCHTEXT'] as $match ) {
 						$sanitized_string = $this->sanitize_string( $match, array( 'html' ) );
 						if ( stripos( $sanitized_string, $check_info['match-text'] ) !== false ) {
-							$filename = $this->get_filename( $file_path );
 							$lines = array_merge( $this->grep_content( $match, $file_content ), $lines );
-							$this->add_error(
-								$check,
-								$check_info['note'],
-								$check_info['level'],
-								$filename,
-								$lines
-							);
 							$result = false;
 						}
+					}
+
+					if ( ! empty( $lines ) ) {
+						$filename = $this->get_filename( $file_path );
+						$this->add_error(
+							$check,
+							$check_info['note'],
+							$check_info['level'],
+							$filename,
+							$lines
+						);
 					}
 				}
 			}

--- a/vip-scanner/checks/URISchemeCheck.php
+++ b/vip-scanner/checks/URISchemeCheck.php
@@ -32,7 +32,7 @@ class URISchemeCheck extends BaseCheck
 			),
 		);
 
-		foreach ( $this->filter_files( $files,'css' ) as $file_path => $file_content ) {
+		foreach ( $this->filter_files( $files,array( 'css', 'js' ) ) as $file_path => $file_content ) {
 			foreach ( $checks as $check => $check_info ) {
 				$this->increment_check_count();
 				$sanitized_string = $this->sanitize_string( $file_content );

--- a/vip-scanner/checks/URISchemeCheck.php
+++ b/vip-scanner/checks/URISchemeCheck.php
@@ -24,6 +24,10 @@ class URISchemeCheck extends BaseCheck
 	function check( $files ) {
 		$result = true;
 
+		/*
+		 * CSS and JS files
+		 */
+
 		$checks = array(
 			'hardcoded-http-scheme' => array(
 				'expression' => '/(?<MATCHTEXT>(http):\/\/([\da-z\.-]+[a-z\.]{2,6})(?:[\/\w \.-]*)*)/msi',
@@ -49,6 +53,43 @@ class URISchemeCheck extends BaseCheck
 							$lines
 						);
 						$result = false;
+					}
+				}
+			}
+		}
+
+		/*
+		 * PHP Files
+		 */
+
+		$checks = array(
+			'script-and-style-link-hardcoded-http-scheme' => array(
+				'expression' => '/(?:wp_enqueue_script|wp_enqueue_style|wp_register_script|wp_register_style)\((?<MATCHTEXT>.*?)\);/msi',
+				'match-text' => 'http://',
+				'level'      => 'Warning',
+				'note'       => 'Hardcoded URL Scheme.  To prevent "Mixed Content" security warnings, it may be better to use <a href="http://en.wikipedia.org/wiki/Uniform_resource_locator#Protocol-relative_URLs">Protocol-Relative URLs</a>',
+			),
+		);
+
+		foreach ( $this->filter_files( $files, 'php' ) as $file_path => $file_content ) {
+			foreach ( $checks as $check => $check_info ) {
+				$this->increment_check_count();
+				if ( preg_match_all( $check_info['expression'], $file_content, $matches ) ) {
+					$lines = array();
+					foreach ( $matches['MATCHTEXT'] as $match ) {
+						$sanitized_string = $this->sanitize_string( $match );
+						if ( stripos( $sanitized_string, $check_info['match-text'] ) !== false ) {
+							$filename = $this->get_filename( $file_path );
+							$lines = array_merge( $this->grep_content( $match, $file_content ), $lines );
+							$this->add_error(
+								$check,
+								$check_info['note'],
+								$check_info['level'],
+								$filename,
+								$lines
+							);
+							$result = false;
+						}
 					}
 				}
 			}

--- a/vip-scanner/checks/URISchemeCheck.php
+++ b/vip-scanner/checks/URISchemeCheck.php
@@ -36,7 +36,7 @@ class URISchemeCheck extends BaseCheck
 			),
 		);
 
-		foreach ( $this->filter_files( $files,array( 'css', 'js' ) ) as $file_path => $file_content ) {
+		foreach ( $this->filter_files( $files, 'css' ) as $file_path => $file_content ) {
 			foreach ( $checks as $check => $check_info ) {
 				$this->increment_check_count();
 				$sanitized_string = $this->sanitize_string( $file_content );

--- a/vip-scanner/checks/URISchemeCheck.php
+++ b/vip-scanner/checks/URISchemeCheck.php
@@ -1,0 +1,59 @@
+<?php
+
+class URISchemeCheck extends BaseCheck
+{
+	function sanitize_string( $string ) {
+		/**
+		 * Removes Javascript/CSS comment blocks
+		 */
+		$string = preg_replace( '/(\/\*(?:.*)?\*\/)/misU', '', $string );
+
+		/**
+		 * Removes Javascript inline comments
+		 */
+		$string = preg_replace( '/(?<![:])(\/\/(?:.*?)$)/mis', '', $string );
+
+		/**
+		 * Removes HTML comment blocks
+		 */
+		$string = preg_replace( '/(<!--(?:.*)?-->)/misU', '', $string );
+
+		return $string;
+	}
+
+	function check( $files ) {
+		$result = true;
+
+		$checks = array(
+			'hardcoded-http-scheme' => array(
+				'expression' => '/(?<MATCHTEXT>(http):\/\/([\da-z\.-]+[a-z\.]{2,6})(?:[\/\w \.-]*)*)/msi',
+				'level'      => 'Warning',
+				'note'       => 'Hardcoded HTTP',
+			),
+		);
+
+		foreach ( $this->filter_files( $files,'css' ) as $file_path => $file_content ) {
+			foreach ( $checks as $check => $check_info ) {
+				$this->increment_check_count();
+				$sanitized_string = $this->sanitize_string( $file_content );
+				if ( preg_match_all( $check_info['expression'], $sanitized_string, $matches ) ) {
+					$lines = array();
+					foreach ( $matches['MATCHTEXT'] as $match ) {
+						$filename = $this->get_filename( $file_path );
+						$lines = array_merge( $this->grep_content( $match, $file_content ), $lines );
+						$this->add_error(
+							$check,
+							$check_info['note'],
+							$check_info['level'],
+							$filename,
+							$lines
+						);
+						$result = false;
+					}
+				}
+			}
+		}
+
+		return $result;
+	}
+}

--- a/vip-scanner/checks/URISchemeCheck.php
+++ b/vip-scanner/checks/URISchemeCheck.php
@@ -28,7 +28,7 @@ class URISchemeCheck extends BaseCheck
 			'hardcoded-http-scheme' => array(
 				'expression' => '/(?<MATCHTEXT>(http):\/\/([\da-z\.-]+[a-z\.]{2,6})(?:[\/\w \.-]*)*)/msi',
 				'level'      => 'Warning',
-				'note'       => 'Hardcoded HTTP',
+				'note'       => 'Hardcoded URL Scheme.  To prevent "Mixed Content" security warnings, it may be better to use <a href="http://en.wikipedia.org/wiki/Uniform_resource_locator#Protocol-relative_URLs">Protocol-Relative URLs</a>',
 			),
 		);
 

--- a/vip-scanner/checks/URISchemeCheck.php
+++ b/vip-scanner/checks/URISchemeCheck.php
@@ -81,8 +81,32 @@ class URISchemeCheck extends BaseCheck
 				'level'      => 'Warning',
 				'note'       => 'Hardcoded URL Scheme.  To prevent "Mixed Content" security warnings, it may be better to use <a href="http://en.wikipedia.org/wiki/Uniform_resource_locator#Protocol-relative_URLs">Protocol-Relative URLs</a>',
 			),
-			'html-tag-attribute-hardcoded-http-scheme' => array(
-				'expression' => '/<[\s]*?[a-z]*[\s].*(?:action|data|formaction|icon|manifest|poster|src)[\s]*?=[\'\"]?(?<MATCHTEXT>http:\/\/[0-9a-z\.-]+?[a-z\.]{2,6}[0-9a-z$\/\-\_\.\+\!\*\'\(\)\,\?\#\&\;\=\%]+?)[\'\"]?.*>/msiU',
+			'html-object-tag-data-attribute-hardcoded-http-scheme' => array(
+				'expression' => '/<[\s]*?object[\s].*data[\s]*?=[\'\"]?(?<MATCHTEXT>http:\/\/[0-9a-z\.-]+?[a-z\.]{2,6}[0-9a-z$\/\-\_\.\+\!\*\'\(\)\,\?\#\&\;\=\%]+?)[\'\"]?.*>/msiU',
+				'match-text' => 'http://',
+				'level'      => 'Warning',
+				'note'       => 'Hardcoded URL Scheme.  To prevent "Mixed Content" security warnings, it may be better to use <a href="http://en.wikipedia.org/wiki/Uniform_resource_locator#Protocol-relative_URLs">Protocol-Relative URLs</a>',
+			),
+			'html-menuitem-tag-icon-attribute-hardcoded-http-scheme' => array(
+				'expression' => '/<[\s]*?menuitem[\s].*icon[\s]*?=[\'\"]?(?<MATCHTEXT>http:\/\/[0-9a-z\.-]+?[a-z\.]{2,6}[0-9a-z$\/\-\_\.\+\!\*\'\(\)\,\?\#\&\;\=\%]+?)[\'\"]?.*>/msiU',
+				'match-text' => 'http://',
+				'level'      => 'Warning',
+				'note'       => 'Hardcoded URL Scheme.  To prevent "Mixed Content" security warnings, it may be better to use <a href="http://en.wikipedia.org/wiki/Uniform_resource_locator#Protocol-relative_URLs">Protocol-Relative URLs</a>',
+			),
+			'html-html-tag-manifest-attribute-hardcoded-http-scheme' => array(
+				'expression' => '/<[\s]*?html[\s].*manifest[\s]*?=[\'\"]?(?<MATCHTEXT>http:\/\/[0-9a-z\.-]+?[a-z\.]{2,6}[0-9a-z$\/\-\_\.\+\!\*\'\(\)\,\?\#\&\;\=\%]+?)[\'\"]?.*>/msiU',
+				'match-text' => 'http://',
+				'level'      => 'Warning',
+				'note'       => 'Hardcoded URL Scheme.  To prevent "Mixed Content" security warnings, it may be better to use <a href="http://en.wikipedia.org/wiki/Uniform_resource_locator#Protocol-relative_URLs">Protocol-Relative URLs</a>',
+			),
+			'html-video-tag-poster-attribute-hardcoded-http-scheme' => array(
+				'expression' => '/<[\s]*?video[\s].*poster[\s]*?=[\'\"]?(?<MATCHTEXT>http:\/\/[0-9a-z\.-]+?[a-z\.]{2,6}[0-9a-z$\/\-\_\.\+\!\*\'\(\)\,\?\#\&\;\=\%]+?)[\'\"]?.*>/msiU',
+				'match-text' => 'http://',
+				'level'      => 'Warning',
+				'note'       => 'Hardcoded URL Scheme.  To prevent "Mixed Content" security warnings, it may be better to use <a href="http://en.wikipedia.org/wiki/Uniform_resource_locator#Protocol-relative_URLs">Protocol-Relative URLs</a>',
+			),
+			'html-tag-src-attribute-hardcoded-http-scheme' => array(
+				'expression' => '/<[\s]*?(?:audio|embed|iframe|img|input|script|source|track|video)[\s].*src[\s]*?=[\'\"]?(?<MATCHTEXT>http:\/\/[0-9a-z\.-]+?[a-z\.]{2,6}[0-9a-z$\/\-\_\.\+\!\*\'\(\)\,\?\#\&\;\=\%]+?)[\'\"]?.*>/msiU',
 				'match-text' => 'http://',
 				'level'      => 'Warning',
 				'note'       => 'Hardcoded URL Scheme.  To prevent "Mixed Content" security warnings, it may be better to use <a href="http://en.wikipedia.org/wiki/Uniform_resource_locator#Protocol-relative_URLs">Protocol-Relative URLs</a>',

--- a/vip-scanner/checks/URISchemeCheck.php
+++ b/vip-scanner/checks/URISchemeCheck.php
@@ -81,6 +81,12 @@ class URISchemeCheck extends BaseCheck
 				'level'      => 'Warning',
 				'note'       => 'Hardcoded URL Scheme.  To prevent "Mixed Content" security warnings, it may be better to use <a href="http://en.wikipedia.org/wiki/Uniform_resource_locator#Protocol-relative_URLs">Protocol-Relative URLs</a>',
 			),
+			'html-tag-attribute-hardcoded-http-scheme' => array(
+				'expression' => '/<[\s]*?[a-z]*[\s].*(?:action|data|formaction|icon|manifest|poster|src)[\s]*?=[\'\"]?(?<MATCHTEXT>http:\/\/[0-9a-z\.-]+?[a-z\.]{2,6}[0-9a-z$\/\-\_\.\+\!\*\'\(\)\,\?\#\&\;\=\%]+?)[\'\"]?.*>/msiU',
+				'match-text' => 'http://',
+				'level'      => 'Warning',
+				'note'       => 'Hardcoded URL Scheme.  To prevent "Mixed Content" security warnings, it may be better to use <a href="http://en.wikipedia.org/wiki/Uniform_resource_locator#Protocol-relative_URLs">Protocol-Relative URLs</a>',
+			),
 		);
 
 		foreach ( $this->filter_files( $files, 'php' ) as $file_path => $file_content ) {
@@ -89,7 +95,44 @@ class URISchemeCheck extends BaseCheck
 				if ( preg_match_all( $check_info['expression'], $file_content, $matches ) ) {
 					$lines = array();
 					foreach ( $matches['MATCHTEXT'] as $match ) {
-						$sanitized_string = $this->sanitize_string( $match, array( 'php' ) );
+						$sanitized_string = $this->sanitize_string( $match, array( 'php', 'html' ) );
+						if ( stripos( $sanitized_string, $check_info['match-text'] ) !== false ) {
+							$filename = $this->get_filename( $file_path );
+							$lines = array_merge( $this->grep_content( $match, $file_content ), $lines );
+							$this->add_error(
+								$check,
+								$check_info['note'],
+								$check_info['level'],
+								$filename,
+								$lines
+							);
+							$result = false;
+						}
+					}
+				}
+			}
+		}
+
+		/*
+		 * HTML Files
+		 */
+
+		$checks = array(
+			'html-tag-attribute-hardcoded-http-scheme' => array(
+				'expression' => '/<[\s]*?[a-z]*[\s].*(?:action|data|formaction|icon|manifest|poster|src)[\s]*?=[\'\"]?(?<MATCHTEXT>http:\/\/[0-9a-z\.-]+?[a-z\.]{2,6}[0-9a-z$\/\-\_\.\+\!\*\'\(\)\,\?\#\&\;\=\%]+?)[\'\"]?.*>/msiU',
+				'match-text' => 'http://',
+				'level'      => 'Warning',
+				'note'       => 'Hardcoded URL Scheme.  To prevent "Mixed Content" security warnings, it may be better to use <a href="http://en.wikipedia.org/wiki/Uniform_resource_locator#Protocol-relative_URLs">Protocol-Relative URLs</a>',
+			),
+		);
+
+		foreach ( $this->filter_files( $files, 'html' ) as $file_path => $file_content ) {
+			foreach ( $checks as $check => $check_info ) {
+				$this->increment_check_count();
+				if ( preg_match_all( $check_info['expression'], $file_content, $matches ) ) {
+					$lines = array();
+					foreach ( $matches['MATCHTEXT'] as $match ) {
+						$sanitized_string = $this->sanitize_string( $match, array( 'html' ) );
 						if ( stripos( $sanitized_string, $check_info['match-text'] ) !== false ) {
 							$filename = $this->get_filename( $file_path );
 							$lines = array_merge( $this->grep_content( $match, $file_content ), $lines );

--- a/vip-scanner/checks/URISchemeCheck.php
+++ b/vip-scanner/checks/URISchemeCheck.php
@@ -30,7 +30,7 @@ class URISchemeCheck extends BaseCheck
 
 		$checks = array(
 			'hardcoded-http-scheme' => array(
-				'expression' => '/(?<MATCHTEXT>(http):\/\/([\da-z\.-]+[a-z\.]{2,6})(?:[\/\w \.-]*)*)/msi',
+				'expression' => '/(?<MATCHTEXT>http:\/\/)/msi',
 				'level'      => 'Warning',
 				'note'       => 'Hardcoded URL Scheme.  To prevent "Mixed Content" security warnings, it may be better to use <a href="http://en.wikipedia.org/wiki/Uniform_resource_locator#Protocol-relative_URLs">Protocol-Relative URLs</a>',
 			),
@@ -44,7 +44,7 @@ class URISchemeCheck extends BaseCheck
 					$lines = array();
 					foreach ( $matches['MATCHTEXT'] as $match ) {
 						$filename = $this->get_filename( $file_path );
-						$lines = array_merge( $this->grep_content( $match, $file_content ), $lines );
+						$lines = array_merge( $this->grep_content( $match, $sanitized_string ), $lines );
 						$this->add_error(
 							$check,
 							$check_info['note'],

--- a/vip-scanner/class-base-check.php
+++ b/vip-scanner/class-base-check.php
@@ -57,13 +57,13 @@ abstract class BaseCheck
 		$files = (array) $files;
 		if ( $type ) {
 			if ( is_array( $type ) ) {
-				$file_types = array();
+				$files_of_multiple_types = array();
 				foreach ( $type as $single_type ) {
 					if ( isset( $files[ $single_type ] ) ) {
-						$file_types = array_merge( $file_types, $files[ $single_type ] );
+						$files_of_multiple_types = array_merge( $files_of_multiple_types, $files[ $single_type ] );
 					}
 				}
-				return $file_types;
+				return $files_of_multiple_types;
 			} else {
 				if ( isset( $files[ $type ] ) ) {
 					return $files[ $type ];

--- a/vip-scanner/class-base-check.php
+++ b/vip-scanner/class-base-check.php
@@ -55,11 +55,23 @@ abstract class BaseCheck
 
 	protected function filter_files( $files, $type = '' ) {
 		$files = (array) $files;
-		if( $type ) {
-			if( isset( $files[$type] ) )
-				return $files[$type];
-			else
-				return array();
+		if ( $type ) {
+			if ( is_array( $type ) ) {
+				$file_types = array();
+				foreach ( $type as $single_type ) {
+					if ( isset( $files[ $single_type ] ) ) {
+						$file_types = array_merge( $file_types, $files[ $single_type ] );
+					}
+				}
+				return $file_types;
+			} else {
+				if ( isset( $files[ $type ] ) ) {
+					return $files[ $type ];
+				}
+				else {
+					return array();
+				}
+			}
 		}
 		return $files;
 	}

--- a/vip-scanner/config-vip-scanner.php
+++ b/vip-scanner/config-vip-scanner.php
@@ -73,6 +73,7 @@ VIP_Scanner::get_instance()->register_review( 'VIP Theme Review', array(
 	'WordPressCodingStandardsCheck',
 	'ClamAVCheck', // Pass null to lookup the check normally
 	'AdBustersCheck',
+	'URISchemeCheck',
 ), array(
 	'PHPAnalyzer',
 	'CustomResourceAnalyzer',


### PR DESCRIPTION
As per GitHub Issue #216, there are good reasons to use protocol-relevant URLs.  This pull request includes some basic scanning for this:
- CSS and JS files
- PHP files, specifically for WordPress functions that enqueue and register scripts and styles (`wp_enqueue_script()`, `wp_enqueue_style()`, `wp_register_script()`, and `wp_register_style()`)
- HTML tags and attributes inside PHP and HTML files that might cause a mixed content browser warning.

The HTML tags scanned for are:
- `<object>` and _'data'_
- `<menuitem>` and _'icon'_
- `<html>` and _'manifest'_
- `<video>` and _'poster'_
- `<audio>`, `<embed>`, `<iframe>`, `<img>`, `<input>`, `<script>`, `<source>`, `<track>`, `<video>` and _'src'_
- `<link>` and _'href'_ only if _'rel'_ is _'stylesheet'_

These tags and attributes were gathered from the [W3C's list](http://www.w3.org/html/wg/drafts/html/master/index.html#attributes-1).

Before the files are scanned, the comments are stripped out so that we help reduce the number of false positives.

This isn't a definitive scan, but it should help catch many of the common cases.
