### PR TITLE
Removed reference to VIPRestrictedVariablesCheck that was left over.

### DIFF
--- a/vip-scanner/config-vip-scanner.php
+++ b/vip-scanner/config-vip-scanner.php
@@ -61,7 +61,6 @@ VIP_Scanner::get_instance()->register_review( 'VIP Theme Review', array(
 	'jQueryCheck',
 	'VIPWhitelistCheck',
 	'VIPRestrictedClassesCheck',
-	'VIPRestrictedVariablesCheck',
 	'VIPRestrictedPatternsCheck',
 	'VIPRestrictedCommandsCheck',
 	'VIPInitCheck',


### PR DESCRIPTION
After refactoring `VIPRestrictedVariablesCheck` into `VIPRestrictedPatternsCheck` I missed removing the reference in `config-vip-scanner.php` causing a `Check "VIPRestrictedVariablesCheck" does not exist.` message.