### PR TITLE
Fix inconsistent caching of scan results

### DIFF
--- a/vip-scanner/vip-scanner-async.php
+++ b/vip-scanner/vip-scanner-async.php
@@ -2,7 +2,6 @@
 
 class VIP_Scanner_Async {
 	const SCANNER_RESULT_CPT = 'scanresult';
-	const REVIEW_TAXONOMY = 'vip-scan-review';
 
 	private static $instance;
 
@@ -54,7 +53,6 @@ class VIP_Scanner_Async {
 			'label'  => self::SCANNER_RESULT_CPT,
 		) );
 
-		register_taxonomy( self::REVIEW_TAXONOMY, self::SCANNER_RESULT_CPT, array( 'public' => false ) );
 	}
 
 	function admin_init() {
@@ -171,7 +169,7 @@ class VIP_Scanner_Async {
 		$data = array(
 			'theme'  => wp_get_theme()->display( 'Name' ),
 			'review' => $review,
-			'issues' => $this->get_cached_results_summary( $review ),
+			'issues' => $this->get_cached_results_summary( $review, $this->get_theme_path( get_stylesheet() ) ),
 		);
 
 		wp_send_json_success( $data );
@@ -268,21 +266,12 @@ class VIP_Scanner_Async {
 		$this->insert_cache_post( $review, $path, $results, $error_counts );
 	}
 
-	function get_cached_results_summary( $review = null, $path = null ) {
+	function get_cached_results_summary( $review, $path ) {
 		$query_args = array(
 			'post_type' => self::SCANNER_RESULT_CPT,
 			'fields'    => 'ids',
+			'name'      => $this->generate_scanresult_post_name( $review, $path )
 		);
-
-		// Do a post name query if the path is specified
-		if ( ! is_null( $path ) ) {
-			$query_args['name'] = sanitize_title_with_dashes( $this->normalize_path_str( $path ) );
-		}
-
-		// Do a post name query if the review is specified
-		if ( ! is_null( $review ) ) {
-			$query_args['name'] .= sanitize_title_with_dashes( $review );
-		}
 
 		// Do the query and parse the issue counts
 		$issues = array_fill_keys( $this->report_levels, 0 );
@@ -301,19 +290,18 @@ class VIP_Scanner_Async {
 	}
 
 	private function insert_cache_post( $review, $path, $results, $error_counts ) {
-		$review_slug     = sanitize_title_with_dashes( $review );
-		$normalized_path = sanitize_title_with_dashes( $this->normalize_path_str( $path ) );
+		$post_name_slug = $this->generate_scanresult_post_name( $review, $path );
 
 		$post_args = array(
 			'post_type'    => self::SCANNER_RESULT_CPT,
-			'post_name'    => $normalized_path.$review_slug,
+			'post_name'    => $post_name_slug,
 			'post_date'    => date( 'Y-m-d H:i:s' ),
 		);
 
 		// Check if the post already exists and add the id to args if it does
 		$posts_query = new WP_Query( array(
 			'post_type'			  => self::SCANNER_RESULT_CPT,
-			'name'				  => $normalized_path.$review_slug,
+			'name'				  => $post_name_slug,
 			'fields'			  => 'ids',
 		) );
 
@@ -352,6 +340,12 @@ class VIP_Scanner_Async {
 
 	private function get_theme_path( $theme ) {
 		return $this->normalize_path_str( sprintf( '%s/%s', get_theme_root(), $theme ) );
+	}
+
+	private function generate_scanresult_post_name( $review, $path ) {
+		$normalized_path = sanitize_title_with_dashes( $this->normalize_path_str( $path ) );
+		$review_slug     = sanitize_title_with_dashes( $review );
+		return $normalized_path.'-'.$review_slug;
 	}
 }
 


### PR DESCRIPTION
Change cache structure from storing theme path in post name to storing
in post meta instead. This is because WP_Query does not behave as
intended when dealing with duplicate post names (it assumes all post
name to be unique) and in this case would ignore taxonomy criteria if
there's a post name match, resulting in wrong cache returned.

This also addresses issue #144 and allows toolbar to display correct
count from cache as intended.