### PR TITLE
Add checks for trigger_error and set_error_handler

### DIFF
--- a/tests/checks/test-VIPRestrictedCommandsCheck.php
+++ b/tests/checks/test-VIPRestrictedCommandsCheck.php
@@ -114,8 +114,8 @@ class VIPRestrictedCommandsTest extends CodeCheckTestBase {
 			array( 'slug' => 'wp_debug_backtrace_summary', 'level' => 'Blocker', 'description' => "Unfiltered filesystem information output", 'file' => 'VIPRestrictedCommandsCheck7.inc', 'lines' => ++$line ),
 			array( 'slug' => 'debug_backtrace',            'level' => 'Blocker', 'description' => "Unfiltered filesystem information output", 'file' => 'VIPRestrictedCommandsCheck7.inc', 'lines' => ++$line ),
 			array( 'slug' => 'debug_print_backtrace',      'level' => 'Blocker', 'description' => "Unfiltered filesystem information output", 'file' => 'VIPRestrictedCommandsCheck7.inc', 'lines' => ++$line ),
-			array( 'slug' => 'trigger_error',   		   'level' => 'Blocker', 'description' => "Triggered error message not accessible",   'file' => 'VIPRestrictedCommandsCheck7.inc', 'lines' => ++$line ),
-			array( 'slug' => 'set_error_handler',		   'level' => 'Blocker', 'description' => "User-defined error handler not supported", 'file' => 'VIPRestrictedCommandsCheck7.inc', 'lines' => ++$line ),
+			array( 'slug' => 'trigger_error',              'level' => 'Blocker', 'description' => "Triggered error message not accessible",   'file' => 'VIPRestrictedCommandsCheck7.inc', 'lines' => ++$line ),
+			array( 'slug' => 'set_error_handler',          'level' => 'Blocker', 'description' => "User-defined error handler not supported", 'file' => 'VIPRestrictedCommandsCheck7.inc', 'lines' => ++$line ),
 		);
 		$actual_errors = $this->checkFile( 'VIPRestrictedCommandsCheck7.inc' );
 		$this->assertEqualErrors( $expected_errors, $actual_errors );

--- a/tests/checks/test-VIPRestrictedCommandsCheck.php
+++ b/tests/checks/test-VIPRestrictedCommandsCheck.php
@@ -114,6 +114,8 @@ class VIPRestrictedCommandsTest extends CodeCheckTestBase {
 			array( 'slug' => 'wp_debug_backtrace_summary', 'level' => 'Blocker', 'description' => "Unfiltered filesystem information output", 'file' => 'VIPRestrictedCommandsCheck7.inc', 'lines' => ++$line ),
 			array( 'slug' => 'debug_backtrace',            'level' => 'Blocker', 'description' => "Unfiltered filesystem information output", 'file' => 'VIPRestrictedCommandsCheck7.inc', 'lines' => ++$line ),
 			array( 'slug' => 'debug_print_backtrace',      'level' => 'Blocker', 'description' => "Unfiltered filesystem information output", 'file' => 'VIPRestrictedCommandsCheck7.inc', 'lines' => ++$line ),
+			array( 'slug' => 'trigger_error',   		   'level' => 'Blocker', 'description' => "Triggered error message not accessible",   'file' => 'VIPRestrictedCommandsCheck7.inc', 'lines' => ++$line ),
+			array( 'slug' => 'set_error_handler',		   'level' => 'Blocker', 'description' => "User-defined error handler not supported", 'file' => 'VIPRestrictedCommandsCheck7.inc', 'lines' => ++$line ),
 		);
 		$actual_errors = $this->checkFile( 'VIPRestrictedCommandsCheck7.inc' );
 		$this->assertEqualErrors( $expected_errors, $actual_errors );

--- a/tests/data/VIPRestrictedCommandsCheck7.inc
+++ b/tests/data/VIPRestrictedCommandsCheck7.inc
@@ -8,3 +8,5 @@ var_export();
 wp_debug_backtrace_summary();
 debug_backtrace();
 debug_print_backtrace();
+trigger_error();
+set_error_handler();

--- a/vip-scanner/checks/VIPRestrictedCommandsCheck.php
+++ b/vip-scanner/checks/VIPRestrictedCommandsCheck.php
@@ -77,6 +77,8 @@ class VIPRestrictedCommandsCheck extends CodeCheck
 			"wp_debug_backtrace_summary" => array( "level" => "Blocker", "note" => "Unfiltered filesystem information output" ),
 			"debug_backtrace" => array( "level" => "Blocker", "note" => "Unfiltered filesystem information output" ),
 			"debug_print_backtrace" => array( "level" => "Blocker", "note" => "Unfiltered filesystem information output" ),
+			"trigger_error"	=> array( "level" => "Blocker", "note" => "Triggered error message not accessible" ),
+			"set_error_handler"	=> array( "level" => "Blocker", "note" => "User-defined error handler not supported" ),
 
 
 			// other


### PR DESCRIPTION
Add checks per issue #272:
> trigger_error() doesn't make much sense, as there is no access to the
log file this will produce...and if you intentionally throw a fatal
error, that's doubly bad.
> set_error_handler() is not supported.

Relevant tests are also added