### PR TITLE
Add checks for batcache variant

### DIFF
--- a/tests/checks/test-BatcacheVariantCheck.php
+++ b/tests/checks/test-BatcacheVariantCheck.php
@@ -1,0 +1,28 @@
+<?php
+
+require_once( 'CodeCheckTestBase.php' );
+
+class BatcacheVariantTest extends CodeCheckTestBase {
+
+	public function testBatcacheVariant() {
+		$expected_errors = array(
+			array(
+				'slug' => 'batcache-variant-error',
+				'level' => BaseScanner::LEVEL_BLOCKER,
+				'description' => 'Illegal word in variant determiner.',
+				'file' => 'BatcacheVariantTest.inc',
+				'lines' => 7,
+			),
+			array(
+				'slug' => 'batcache-variant-error',
+				'level' => BaseScanner::LEVEL_BLOCKER,
+				'description' => 'Variant determiner should refer to at least one $_ variable.',
+				'file' => 'BatcacheVariantTest.inc',
+				'lines' => 7,
+			),
+		);
+		$actual_errors = $this->checkFile( 'BatcacheVariantTest.inc' );
+		$this->assertEqualErrors( $expected_errors, $actual_errors );
+	}
+
+}

--- a/tests/data/BatcacheVariantTest.inc
+++ b/tests/data/BatcacheVariantTest.inc
@@ -1,0 +1,12 @@
+<?php
+
+die(); //Don't actually run the following code.
+
+function is_feedburner() {
+    if ( function_exists( 'vary_cache_on_function' ) ) {
+		vary_cache_on_function(	'require("something_dangerous.php");' );
+    }
+    return (bool) preg_match("/feedburner|feedvalidator/i", $_SERVER["HTTP_USER_AGENT"]);
+}
+
+

--- a/vip-scanner/checks/BatcacheVariantCheck.php
+++ b/vip-scanner/checks/BatcacheVariantCheck.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Checks for invalid batcache variant function vary_cache_on_function() that:
+ * 
+ * - includes dangerous illegal functions
+ * - does not reference superglobal variable
+ *
+ */
+
+class BatcacheVariantCheck extends CodeCheck {
+
+	function __construct() {
+		parent::__construct( array(
+			'PhpParser\Node\Expr\FuncCall' => function( $node ) {
+				$name = $node->name->toString();
+				if ( 'vary_cache_on_function' == $name ) {
+
+					$value = $node->args[0]->value;
+
+					if ( $value instanceof PhpParser\Node\Scalar\String )  {
+
+						$function_string = $value->value;
+
+						if ( preg_match('/include|require|echo|print|dump|export|open|sock|unlink|`|eval/i', $function_string) ) {
+							$this->add_error(
+								'batcache-variant-error',
+								'Illegal word in variant determiner.',
+								BaseScanner::LEVEL_BLOCKER
+							);
+						}
+
+						if ( !preg_match('/\$_/', $function_string) ) {
+							$this->add_error(
+								'batcache-variant-error',
+								'Variant determiner should refer to at least one $_ variable.',
+								BaseScanner::LEVEL_BLOCKER
+							);
+						}
+					}
+				}
+			}
+		) );
+	}
+
+
+}

--- a/vip-scanner/config-vip-scanner.php
+++ b/vip-scanner/config-vip-scanner.php
@@ -11,6 +11,7 @@ VIP_Scanner::get_instance()->register_review( 'Undefined Function Check', array(
 
 VIP_Scanner::get_instance()->register_review( 'WP.com Theme Review', array(
 	'AtPackageCheck',
+	'BatCacheVariantCheck',
 	'BodyClassCheck',
 	'CDNCheck',
 	'CheckedSelectedDisabledCheck',
@@ -54,6 +55,7 @@ VIP_Scanner::get_instance()->register_review( 'WP.com Theme Review', array(
 ) );
 
 VIP_Scanner::get_instance()->register_review( 'VIP Theme Review', array(
+	'BatCacheVariantCheck',
 	'CheckedSelectedDisabledCheck',
 	'DeprecatedConstantsCheck',
 	'DeprecatedFunctionsCheck',


### PR DESCRIPTION
Add checks per issue #153:
> A variant that includes one of
include|require|echo|print|dump|export|open|sock|unlink||eval or does
*not* include a reference to a superglobal (regex check for$_`) will
fail and we should flag those early.

Test case also added