### PR TITLE
Get instance of VIP_Scanner_UI to get default_review property

### DIFF
--- a/vip-scanner/class.vip-scanner-form.php
+++ b/vip-scanner/class.vip-scanner-form.php
@@ -133,9 +133,8 @@ class VIP_Scanner_Form {
 	}
 
 	private static function is_review_type( $type ) {
-		global $vip_scanner;
 		$review_types = VIP_Scanner::get_instance()->get_review_types();
-		$cur = isset( $_REQUEST['vip-scanner-review-type'] ) ? $_REQUEST['vip-scanner-review-type'] : $review_types[$vip_scanner->default_review];
+		$cur = isset( $_REQUEST['vip-scanner-review-type'] ) ? $_REQUEST['vip-scanner-review-type'] : $review_types[ VIP_Scanner_UI::get_instance()->default_review ];
 		return $cur == $type;
 	}
 


### PR DESCRIPTION
As soon as I loaded the plugin and went to Tools > Vip Scanner there was a notice.
![selection_006](https://cloud.githubusercontent.com/assets/204463/10571102/4f7b4b5e-7601-11e5-99c1-6c0054a00de6.png)

I didn't found where the [global $vip_scanner](https://github.com/Automattic/vip-scanner/blob/b55811e29f2da67bdc9a0570be115217cabfbfbc/vip-scanner/class.vip-scanner-form.php#L136) was defined, so I changed it to the same way it's used [somewhere else](https://github.com/Automattic/vip-scanner/blob/b55811e29f2da67bdc9a0570be115217cabfbfbc/vip-scanner/vip-scanner-async.php#L223).