### PR TITLE
Adding three checks for non-escaped localization function calls.

### DIFF
--- a/tests/checks/test-VIPEscapingCheck.php
+++ b/tests/checks/test-VIPEscapingCheck.php
@@ -1,0 +1,101 @@
+<?php
+
+require_once( 'CodeCheckTestBase.php' );
+
+class VIPEscapingTest extends CodeCheckTestBase {
+
+	public function testEscaping() {
+		$lines = 3;
+
+		$expected_errors = array();
+
+	
+		/*
+		 * Why 4 * 5? Why a the loop?
+		 * Because we are specifying very similar
+		 * test-result, again and again.
+		 *
+		 * First, four tests for echo (without brackets)
+		 * 	echo __( ... );
+		 * 	echo _x( ... );
+		 *	echo _n( ... );
+		 * 	echo _nx( ... );
+		 *
+		 * Second, four similar tests for echo with brackets
+		 * Third, four similar tests for print without brackets
+ 		 * Fourth, four similar tests for print with brackets
+		 * Fifth, four simila tests for vprintf (with brackets)
+		 *
+		 * Note: If you find yourself adding 'ifs' within the
+		 * for-loop, stop using a loop and write out each
+		 * expected error individually.
+		 */
+
+		for ($i = 0; $i < 4 * 5; $i++) {
+			$expected_errors[] = array(
+				'slug' => 'functions-file',
+				'level' => BaseScanner::LEVEL_BLOCKER,
+				'description' => sprintf(
+					esc_html__( 'Printing output of non-escaping localization functions (i.e. %1$s) is potentially dangerous, as they do not escape HTML. An escaping function (e.g. %2$s) should be used rather.', 'vip-scanner' ),
+					'<code>__( ), _x( ), _n( ), _nx( )</code>',
+					'<code>esc_html__( ), esc_attr__( ), esc_html_x( ), esc_attr_x( )</code>'
+				),
+				'file' => 'VIPEscapingTest.inc',
+				'lines' => $lines++,
+			);
+		}
+
+		$lines++;
+
+
+		/*
+		 * Now test for non-printing usage of __( ), _x( ),
+		 * _n( ), and _nx( ).
+		 *
+		 * Note: If you find yourself adding 'ifs' within the
+		 * for-loop, stop using a loop and write out each
+		 * expected error individually.
+		 */
+
+		for ($i = 0; $i < 4; $i++) {
+			$expected_errors[] = array(
+				'slug' => 'functions-file',
+				'level' => BaseScanner::LEVEL_WARNING,
+				'description' => sprintf(
+					esc_html__( 'Usage of non-escaping localization functions (i.e. %1$s) is discouraged as they do not escape HTML. An escaping function (e.g. %2$s) should be used rather.', 'vip-scanner' ),
+					'<code>__( ), _x( ), _n( ), _nx( )</code>',
+					'<code>esc_html__( ), esc_attr__( ), esc_html_x( ), esc_attr_x( )</code>'
+				),
+				'file' => 'VIPEscapingTest.inc',
+				'lines' => $lines++,
+			);
+		}
+
+
+		/*
+		 * Now test for usage of _e( ), _ex( ).
+		 *
+		 * Note: If you find yourself adding 'ifs' within the
+		 * for-loop, stop using a loop and write out each
+		 * expected error individually.
+		 */
+
+		for ($i = 0; $i < 2; $i++) {
+			$expected_errors[] = array(
+				'slug' => 'functions-file',
+				'level' => BaseScanner::LEVEL_BLOCKER,
+				'description' => sprintf(
+					esc_html__( 'Usage of non-escaping localization functions (i.e. %1$s) is discouraged as they do not escape HTML. An escaping function (e.g. %2$s) should be used rather.', 'vip-scanner' ),
+					'<code>_e( ), _ex( )</code>',
+					'<code>esc_html_e( ), esc_attr_e( ), esc_html_x( ), esc_attr_x( ), esc_attr__( )</code>'
+				),
+				'file' => 'VIPEscapingTest.inc',
+				'lines' => $lines++,
+			);
+		}
+
+
+		$actual_errors = $this->checkFile( 'VIPEscapingTest.inc' );
+		$this->assertEqualErrors( $expected_errors, $actual_errors );
+	}
+}

--- a/tests/data/VIPEscapingTest.inc
+++ b/tests/data/VIPEscapingTest.inc
@@ -1,0 +1,30 @@
+<?php
+
+die(); //Don't actually run the following code.
+
+echo __( 'Message #1' );
+echo _x( 'Message #1' );
+echo _n( 'Message #1' );
+echo _nx( 'Message #1' );
+echo( __( 'Message #1' ) );
+echo( _x( 'Message #1' ) );
+echo( _n( 'Message #1' ) );
+echo( _nx( 'Message #1' ) );
+print __( 'Message #1' );
+print _x( 'Message #1' );
+print _n( 'Message #1' );
+print _nx( 'Message #1' );
+print( __( 'Message #1' ) );
+print( _x( 'Message #1' ) );
+print( _n( 'Message #1' ) );
+print( _nx( 'Message #1' ) );
+vprintf ( __( 'Message #%d' ), 1 );
+vprintf ( _x( 'Message #%d' ), 1 );
+vprintf ( _n( 'Message #%d' ), 1 );
+vprintf ( _nx( 'Message #%d' ), 1 );
+__( 'Message #1' );
+_x( 'Message #1' );
+_n( 'Message #1' );
+_nx( 'Message #1' );
+_e( 'Message #1' );
+_ex( 'Message #1' );

--- a/vip-scanner/checks/VIPEscapingCheck.php
+++ b/vip-scanner/checks/VIPEscapingCheck.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Detect errors in escaping.
+ */
+class VIPEscapingCheck extends BaseCheck {
+	function check( $files ) {
+		$checks = array(
+			array(
+				/*
+				 * Catch printing usage of __( ), etc.
+				 * These are blockers because the results
+				 * are being printed without HTML-escaping the
+				 * results.
+				 */
+				'pattern' => '/([\s]|[;]){1,}(echo|vprintf|print)([\s]|[\(])+(__|_x|_n|_nx)[\s]*?\(/',
+				'level'   => 'blocker',
+				'message' => sprintf( 
+						esc_html__( 'Printing output of non-escaping localization functions (i.e. %1$s) is potentially dangerous, as they do not escape HTML. An escaping function (e.g. %2$s) should be used rather.', 'vip-scanner' ), 
+						'<code>__( ), _x( ), _n( ), _nx( )</code>', 
+						'<code>esc_html__( ), esc_attr__( ), esc_html_x( ), esc_attr_x( )</code>' 
+				),
+			),
+			array(
+				/*
+				 * Catch non-printing usage of __( ), etc
+				 * These are warnings, because the results
+				 * are not being immediately printed, and so
+				 * could be escaped at a later point.
+				 */
+				'pattern' => '/([\s]|[;]|[=]){1,}[a-zA-Z]{0}[\s]+(__|_x|_n|_nx)[\s]*?\(/',
+				'level'   => 'warning',
+				'message' => sprintf( 
+						esc_html__( 'Usage of non-escaping localization functions (i.e. %1$s) is discouraged as they do not escape HTML. An escaping function (e.g. %2$s) should be used rather.', 'vip-scanner' ), 
+						'<code>__( ), _x( ), _n( ), _nx( )</code>', 
+						'<code>esc_html__( ), esc_attr__( ), esc_html_x( ), esc_attr_x( )</code>' 
+				),
+			),
+			array(
+				/*
+				 * Catch calls to _e( ), _ex( )
+				 * These print directly, without HTML-escaping,
+				 * and so are blockers.
+				 */
+				'pattern' => '/([\s]|[;]){1,}[a-zA-Z]{0}[\s]+(_e|_ex)[\s]*?\(/',
+				'level'   => 'blocker',
+				'message' => sprintf( 
+						esc_html__( 'Usage of non-escaping localization functions (i.e. %1$s) is discouraged as they do not escape HTML. An escaping function (e.g. %2$s) should be used rather.', 'vip-scanner' ), 
+						'<code>_e( ), _ex( )</code>', 
+						'<code>esc_html_e( ), esc_attr_e( ), esc_html_x( ), esc_attr_x( ), esc_attr__( )</code>' 
+				),
+			),
+		);
+
+		$result = true;
+		foreach ( $checks as $check ) {
+			$this->increment_check_count();
+			foreach ( $this->filter_files( $files, 'php' ) as $path => $code ) {
+				$filename = $this->get_filename( $path );
+				$errors = $this->preg_file2( $check['pattern'], $code );
+				foreach ( (array) $errors as $line_number => $error ) {
+					$this->add_error(
+						'functions-file',
+						$check['message'],
+						$check['level'],
+						$filename,
+						array( $line_number => $error )
+					);
+					$result = false;
+				}
+			}
+		}
+		return $result;
+	}
+}

--- a/vip-scanner/config-vip-scanner.php
+++ b/vip-scanner/config-vip-scanner.php
@@ -59,6 +59,7 @@ VIP_Scanner::get_instance()->register_review( 'VIP Theme Review', array(
 	'DeprecatedFunctionsCheck',
 	'DeprecatedParametersCheck',
 	'jQueryCheck',
+	'VIPEscapingCheck',
 	'VIPWhitelistCheck',
 	'VIPRestrictedClassesCheck',
 	'VIPRestrictedPatternsCheck',


### PR DESCRIPTION
The first checks if output of the __( ), _x( ), _n( ), _nx( ) functions
is being printed directly, via echo( ), print( ) or vprintf( )
-- care is taken to ensure that both echo with and without
brackets is considered, and same with print. These are blockers.

The second checks if __( ), _x( ), _n( ), _nx( ) functions are
being called (without printing). These are warnings.

The third checks if _e( ) or _ex( ) are being called.
These are blockers.

These checks are all against localization functions which do not
HTML-escape. Not escaping can be dangerous since HTML code could
be injected via malicous translation strings. Blocking was considered
prudent with direct printing, because there is no escaping involved,
whereas warnings are issued when strings are possibly escaped later
on in processing.

This will resolve issue #287.